### PR TITLE
Redirect xdg-open output to dev/null to avoid START... output

### DIFF
--- a/open.tmux
+++ b/open.tmux
@@ -32,7 +32,7 @@ get_editor_from_the_env_var() {
 
 command_generator() {
 	local command_string="$1"
-	echo "xargs -I {} tmux run-shell 'cd #{pane_current_path}; $command_string {}'"
+	echo "xargs -I {} tmux run-shell 'cd #{pane_current_path}; $command_string {} > /dev/null'"
 }
 
 generate_open_command() {


### PR DESCRIPTION
When using tmux-open's o command on Linux, xdg-open will output the following to the tmux pane in which it was executed:

```
START /usr/lib/firefox/firefox "http://example.com"
```

Redirecting to /dev/null avoids this.
