### PR TITLE
Fixed script path and few grammer mistakes

### DIFF
--- a/open.tmux
+++ b/open.tmux
@@ -49,7 +49,7 @@ generate_open_command() {
 		echo "$(command_generator "xdg-open")"
 	else
 		# error command for Linux machines when 'xdg-open' not installed
-		"$CURRENT_DIR/scripts/tmux_open_error_message.sh xdg-open"
+		"$CURRENT_DIR/scripts/tmux_open_error_message.sh" "xdg-open"
 	fi
 }
 
@@ -61,7 +61,7 @@ generate_open_search_command() {
 		echo "$(search_command_generator "xdg-open" "$engine")"
 	else
 		# error command for Linux machines when 'xdg-open' not installed
-		"$CURRENT_DIR/scripts/tmux_open_error_message.sh xdg-open"
+		"$CURRENT_DIR/scripts/tmux_open_error_message.sh" "xdg-open"
 	fi
 }
 

--- a/scripts/tmux_open_error_message.sh
+++ b/scripts/tmux_open_error_message.sh
@@ -2,7 +2,7 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-source "$CURRENT_DIR/scripts/helpers.sh"
+source "$CURRENT_DIR/helpers.sh"
 
 MISSING_PROGRAM="$1"
 


### PR DESCRIPTION
It looks like scripts/tmux\_open\_error\_message.sh is not used in open.tmux script.
I tested modified scripts on non xdg-open installed system (Ubuntu 14), and it displays error message on starting tmux.