### PR TITLE
Adding cygwin support

### DIFF
--- a/open.tmux
+++ b/open.tmux
@@ -21,6 +21,11 @@ is_osx() {
 	[ "$platform" == "Darwin" ]
 }
 
+is_cygwin() {
+        local platform=$(uname)
+        [[ "$platform" =~ CYGWIN(.*) ]]
+}
+
 get_editor_from_the_env_var() {
 	if [ -z $EDITOR ]; then
 		# $EDITOR not set, fallback
@@ -45,6 +50,8 @@ search_command_generator() {
 generate_open_command() {
 	if is_osx; then
 		echo "$(command_generator "open")"
+	elif is_cygwin; then
+		echo "$(command_generator "cygstart")"
 	elif command_exists "xdg-open"; then
 		echo "$(command_generator "xdg-open")"
 	else


### PR DESCRIPTION
Cygwin doesn't have xdg-open yet, so using cygstart is a common workaround for this (see http://www.dwheeler.com/essays/open-files-urls.html ), if this is accepted, adding windows support should be done equally, using "cmd /c start" instead of xdg-open.

Instead of creating these small functions, would it be better to just set platfrom=$(uname) globally and query from there?