### PR TITLE
Correct bindings for newer tmux versions (2.4+)

### DIFF
--- a/open.tmux
+++ b/open.tmux
@@ -88,8 +88,8 @@ set_copy_mode_open_bindings() {
 	local key_bindings=$(get_tmux_option "$open_option" "$default_open_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key -t vi-copy    "$key" copy-pipe "$open_command"
-		tmux bind-key -t emacs-copy "$key" copy-pipe "$open_command"
+		tmux bind-key -Tcopy-mode-vi "$key" send -X copy-pipe "$open_command"
+		tmux bind-key -Tcopy-mode	 "$key" send -X copy-pipe "$open_command"
 	done
 }
 
@@ -98,8 +98,8 @@ set_copy_mode_open_editor_bindings() {
 	local key_bindings=$(get_tmux_option "$open_editor_option" "$default_open_editor_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key -t vi-copy    "$key" copy-pipe "$editor_command"
-		tmux bind-key -t emacs-copy "$key" copy-pipe "$editor_command"
+		tmux bind-key -Tcopy-mode-vi  "$key" send -X copy-pipe "$editor_command"
+		tmux bind-key -Tcopy-mode	  "$key" send -X copy-pipe "$editor_command"
 	done
 }
 
@@ -108,12 +108,10 @@ set_copy_mode_open_search_bindings() {
 	local engine_var
 	local engine
 	local key
-
 	for engine_var in $stored_engine_vars; do
 		engine="$(get_engine "$engine_var")"
-
-		tmux bind-key -t vi-copy    "$engine_var" copy-pipe "$(generate_open_search_command "$engine")"
-		tmux bind-key -t emacs-copy "$engine_var" copy-pipe "$(generate_open_search_command "$engine")"
+		tmux bind-key -Tcopy-mode-vi  "$engine" send -X copy-pipe "$(generate_open_search_command "$engine_var")"
+		tmux bind-key -Tcopy-mode	  "$engine" send -X copy-pipe "$(generate_open_search_command "$engine_var")"
 	done
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -35,7 +35,7 @@ display_message() {
 }
 
 stored_engine_vars() {
-	tmux show-options -g | grep -i "^@open" | cut -d '-' -f2 | cut -d ' ' -f1 | xargs
+	tmux show-options -g | grep -i "^@open-" | cut -d '-' -f2 | cut -d ' ' -f1 | xargs
 }
 
 get_engine() {


### PR DESCRIPTION
Hi!

I changed the binding commands, cause vi-mode and emacs-mode key tables are gone (see https://github.com/tmux/tmux/commit/76d6d3641f271be1756e41494960d96714e7ee58).

And slightly modified **stored_engine_vars** helper function, so it returns only engines after "-".
