### PR TITLE
support tmux 2.4

### DIFF
--- a/open.tmux
+++ b/open.tmux
@@ -88,8 +88,13 @@ set_copy_mode_open_bindings() {
 	local key_bindings=$(get_tmux_option "$open_option" "$default_open_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key -t vi-copy    "$key" copy-pipe "$open_command"
-		tmux bind-key -t emacs-copy "$key" copy-pipe "$open_command"
+		if tmux-is-at-least 2.4; then
+			tmux bind-key -T copy-mode-vi "$key" send-keys -X copy-pipe-and-cancel "$open_command"
+			tmux bind-key -T copy-mode    "$key" send-keys -X copy-pipe-and-cancel "$open_command"
+		else
+			tmux bind-key -t vi-copy    "$key" copy-pipe "$open_command"
+			tmux bind-key -t emacs-copy "$key" copy-pipe "$open_command"
+		fi
 	done
 }
 
@@ -98,8 +103,13 @@ set_copy_mode_open_editor_bindings() {
 	local key_bindings=$(get_tmux_option "$open_editor_option" "$default_open_editor_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key -t vi-copy    "$key" copy-pipe "$editor_command"
-		tmux bind-key -t emacs-copy "$key" copy-pipe "$editor_command"
+		if tmux-is-at-least 2.4; then
+			tmux bind-key -T copy-mode-vi "$key" send-keys -X copy-pipe-and-cancel "$editor_command"
+			tmux bind-key -T copy-mode    "$key" send-keys -X copy-pipe-and-cancel "$editor_command"
+		else
+			tmux bind-key -t vi-copy    "$key" copy-pipe "$editor_command"
+			tmux bind-key -t emacs-copy "$key" copy-pipe "$editor_command"
+		fi
 	done
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -42,3 +42,31 @@ get_engine() {
 	local engine_var="$1"
 	tmux show-options -g | grep -i "^@open-$engine_var" | cut -d ' ' -f2 | xargs
 }
+
+tmux_version="$(tmux -V | cut -d ' ' -f 2)"
+tmux-is-at-least() {
+	if [[ $tmux_version == $1 ]]
+	then
+		return 0
+	fi
+
+	local IFS=.
+	local i tver=($tmux_version) wver=($1)
+
+	# fill empty fields in tver with zeros
+	for ((i=${#tver[@]}; i<${#wver[@]}; i++)); do
+		tver[i]=0
+	done
+
+	# fill empty fields in wver with zeros
+	for ((i=${#wver[@]}; i<${#tver[@]}; i++)); do
+		wver[i]=0
+	done
+
+	for ((i=0; i<${#tver[@]}; i++)); do
+		if ((10#${tver[i]} < 10#${wver[i]})); then
+			return 1
+		fi
+	done
+	return 0
+}


### PR DESCRIPTION
TMUX has changed the way bind-keys works in version 2.4+ This change
supports both older and newer versions.

In addition, I added `tmux-is-at-least` bash function to help with this and future changes in the TMUX commands.