### PR TITLE
Remove redirection to /dev/null, fixing OSX open.

### DIFF
--- a/open.tmux
+++ b/open.tmux
@@ -36,14 +36,14 @@ get_editor_from_the_env_var() {
 
 command_generator() {
 	local command_string="$1"
-	echo "xargs -I {} tmux run-shell 'cd #{pane_current_path}; $command_string \"{}\" > /dev/null'"
+	echo "xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; $command_string \"{}\"'"
 }
 
 search_command_generator() {
 	local command_string="$1"
 	local engine="$2"
 
-	echo "xargs -I {} tmux run-shell 'cd #{pane_current_path}; $command_string $engine\"{}\" > /dev/null'"
+	echo "xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; $command_string $engine\"{}\"'"
 }
 
 generate_open_command() {


### PR DESCRIPTION
To my surprise, nothing happened when I tried to use the `open` functionality. I did some investigation, and it looks like the redirection of output to `/dev/null` when running the command was somehow causing an issue on OSX. There shouldn't be any issue with removing the redirection since the command runs in the background with `-b`, so this pull request hopes to resolve the issue in that manner.

