### PR TITLE
Allowing to search phrases

### DIFF
--- a/open.tmux
+++ b/open.tmux
@@ -43,7 +43,7 @@ search_command_generator() {
 	local command_string="$1"
 	local engine="$2"
 
-	echo "sed 's/\ /+/g | xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; $command_string $engine\"{}\" > /dev/null'"
+	echo "sed 's/\ /+/g' | xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; $command_string $engine\"{}\" > /dev/null'"
 }
 
 generate_open_command() {

--- a/open.tmux
+++ b/open.tmux
@@ -43,7 +43,7 @@ search_command_generator() {
 	local command_string="$1"
 	local engine="$2"
 
-	echo "xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; $command_string $engine\"{}\" > /dev/null'"
+	echo "sed 's/\ /+/g | xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; $command_string $engine\"{}\" > /dev/null'"
 }
 
 generate_open_command() {


### PR DESCRIPTION
Currently I'm getting this unexpected behavior
```
open https://www.google.com/search?q="resources+based policy" > /dev/null' returned 1
```
The engine search doesn't work because of a missing `+` when you have more than 2 words in the target string.