### PR TITLE
Add an @open-pipe option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ set -g @open-S 'https://www.google.com/search?q='
 
 in `tmux.conf`
 
+> How can I change the behavior of copying the selection and quitting the copy-mode when opening a file?
+
+Put: `set -g @open-pipe pipe-and-cancel` or `set -g @open-pipe pipe-no-clear` in `tmux.conf`.
+
 ### Other goodies
 
 `tmux-open` works great with:

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -37,7 +37,7 @@ display_message() {
 stored_engine_vars() {
 	tmux show-options -g |
 		grep -i "^@open-" |
-		grep -vi "^@open-editor" |
+		grep -viE "^@open-(editor|pipe)" |
 		cut -d '-' -f2 |
 		cut -d ' ' -f1 |
 		xargs


### PR DESCRIPTION
tmux-open uses the `copy-pipe-and-cancel` command when opening a file, but the behavior copying the selection and quitting the copy-mode should be optional.

This option allows users to use another variant of pipe commands like `pipe-no-clear` or `pipe-and-cancel` instead of `copy-pipe-and-cancel`.